### PR TITLE
Add a .NET web app building docker file

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,42 @@
+# escape=`
+
+# Copyright (C) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+ARG FROM_IMAGE=microsoft/dotnet-framework:3.5-sdk-windowsservercore-1709
+FROM ${FROM_IMAGE}
+
+# Reset the shell.
+SHELL ["cmd", "/S", "/C"]
+
+# Set up environment to collect install errors.
+COPY Install.cmd C:\TEMP\
+ADD https://aka.ms/vscollect.exe C:\TEMP\collect.exe
+
+# Install Node.js LTS
+ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-x64.msi C:\TEMP\node-install.msi
+RUN start /wait msiexec.exe /i C:\TEMP\node-install.msi /l*vx "%TEMP%\MSI-node-install.log" /qn ADDLOCAL=ALL
+
+# Download channel for fixed install.
+ARG CHANNEL_URL=https://aka.ms/vs/15/release/channel
+ADD ${CHANNEL_URL} C:\TEMP\VisualStudio.chman
+
+# Download and install Build Tools for Visual Studio 2017.
+ADD https://aka.ms/vs/15/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
+    --channelUri C:\TEMP\VisualStudio.chman `
+    --installChannelUri C:\TEMP\VisualStudio.chman `
+    --add Microsoft.VisualStudio.Workload.NetCoreBuildTools`
+    --add Microsoft.VisualStudio.Workload.WebBuildTools`
+    --add Microsoft.VisualStudio.Workload.NodeBuildTools `
+    --add Microsoft.VisualStudio.Component.TypeScript.2.8 `
+    --includeOptional --includeRecommended `
+    --installPath C:\BuildTools
+
+ENV MSBuildBinPath C:\BuildTools\MSBuild\15.0\Bin\
+ENV MSBuildExtensionsPath C:\BuildTools\
+ENV MSBuildExtensionsPath32 C:\BuildTools\
+
+# Use developer command prompt and start PowerShell if no other command specified.
+ENTRYPOINT C:\BuildTools\Common7\Tools\VsDevCmd.bat &&
+CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/web/Install.cmd
+++ b/web/Install.cmd
@@ -1,0 +1,17 @@
+@rem Copyright (C) Microsoft Corporation. All rights reserved.
+@rem Licensed under the MIT license. See LICENSE.txt in the project root for license information.
+
+@if not defined _echo echo off
+setlocal enabledelayedexpansion
+
+call %*
+if "%ERRORLEVEL%"=="3010" (
+    exit /b 0
+) else (
+    if not "%ERRORLEVEL%"=="0" (
+        set ERR=%ERRORLEVEL%
+        call C:\TEMP\collect.exe -zip:C:\vslogs.zip
+
+        exit /b !ERR!
+    )
+)

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,51 @@
+# Web apps
+This sample produces an image that installs required framework and workloads for web app authoring.
+
+We start from the microsoft/dotnet-framework:3.5-sdk-windowsservercore-1709 base image for consistency with the managed-native-desktop sample. We use RS3 because the same image can be used on Windows Server 2016 nodes that do not yet support RS4 containers.
+
+On top of that we add the workloads for building .NET and .NET Core apps. Also add environment variables that point to the `msbuild` and extensions paths. These are used in `.csproj` files to `find` the location of tools.
+
+## Building
+To build this image from this directory, run:
+
+```batch
+docker build -t buildtools2017web:latest -m 2GB .
+```
+## Running with CAKE
+Assuming CAKE is used then a `build.ps1` script should be available. It can be run using the following command from a clean source repository:
+
+```batch
+docker run -m 2G ^
+ -v %CD%:c:\src ^
+ -w c:\src ^
+ buildtools2017web:latest ^
+ powershell .\build.ps1 -Target="Default" -Transform="Debug" -Configuration="Debug
+```
+ - runs `buildtools2017web:latest` and passes in the current working directory `%CD%` and designates it `c:\src` 'inside' the container
+ - designates the working directory to `c:\src`
+ - starts the `build.ps1` script (in this instance with a debug config)
+
+## Running
+To map and build web sources from a clean source repository, run:
+
+```batch
+docker run -m 2G -v %CD%:C:\src buildtools2017web:latest --name Solution msbuild /m c:\src\Solution.sln
+```
+
+You can optionally pass specific configurations to build as well.
+
+```batch
+docker run -m 2G -v %CD%:C:\src buildtools2017web:latest --name Solution msbuild /m c:\src\Solution.sln /p:Configuration=Debug /p:Platform=x64
+```
+
+To build again run the container created in the previous step, e.g.
+```batch
+docker start -a Solution
+```
+
+You can omit the -a that attaches the container to view the output if desired.
+
+## Issues
+
+* If the repository is not clean and the mapped directory is not on the same drive or the same path as the host directory, web project builds will fail with a front-end compiler error.
+* The compile flag /CI causes a compiler error when used in a container. In your project properties under C/C++ change Debug Information Format to C7 compatible when building in a container.


### PR DESCRIPTION
1. Goal is to have a Dockerfile that results in an image capable of building .NET and .NET Core web apps
2. For image building and running see web/readme.md 

#Hello @heaths. Please review. 