### PR TITLE
Upgrade to Visual Studio 2022

### DIFF
--- a/managed-native-desktop/Dockerfile
+++ b/managed-native-desktop/Dockerfile
@@ -18,11 +18,11 @@ ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-x64.msi C:\TEMP\node-install.ms
 RUN start /wait msiexec.exe /i C:\TEMP\node-install.msi /l*vx "%TEMP%\MSI-node-install.log" /qn ADDLOCAL=ALL
 
 # Download channel for fixed install.
-ARG CHANNEL_URL=https://aka.ms/vs/15/release/channel
+ARG CHANNEL_URL=https://aka.ms/vs/17/release/channel
 ADD ${CHANNEL_URL} C:\TEMP\VisualStudio.chman
 
-# Download and install Build Tools for Visual Studio 2017.
-ADD https://aka.ms/vs/15/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+# Download and install Build Tools for Visual Studio 2022.
+ADD https://aka.ms/vs/17/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
     --channelUri C:\TEMP\VisualStudio.chman `
     --installChannelUri C:\TEMP\VisualStudio.chman `

--- a/managed-native-desktop/README.md
+++ b/managed-native-desktop/README.md
@@ -5,14 +5,14 @@ The Visual Studio setup engine builds both managed and native projects. Some man
 To build this image from this direectory, run:
 
 ```batch
-docker build -t buildtools2017:latest -m 2GB .
+docker build -t buildtools2022:latest -m 2GB .
 ```
 
 ## Running
 To map and build managed and native sources from a clean source repository, run:
 
 ```batch
-docker run -m 2G -v %CD%:C:\src buildtools2017:latest msbuild /m c:\src\Solution.sln
+docker run -m 2G -v %CD%:C:\src buildtools2022:latest msbuild /m c:\src\Solution.sln
 ```
 
 ## Issues

--- a/native-desktop/Dockerfile
+++ b/native-desktop/Dockerfile
@@ -18,11 +18,11 @@ ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-x64.msi C:\TEMP\node-install.ms
 RUN start /wait msiexec.exe /i C:\TEMP\node-install.msi /l*vx "%TEMP%\MSI-node-install.log" /qn ADDLOCAL=ALL
 
 # Download channel for fixed install.
-ARG CHANNEL_URL=https://aka.ms/vs/15/release/channel
+ARG CHANNEL_URL=https://aka.ms/vs/17/release/channel
 ADD ${CHANNEL_URL} C:\TEMP\VisualStudio.chman
 
-# Download and install Build Tools for Visual Studio 2017 for native desktop workload.
-ADD https://aka.ms/vs/15/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+# Download and install Build Tools for Visual Studio 2022 for native desktop workload.
+ADD https://aka.ms/vs/17/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
     --channelUri C:\TEMP\VisualStudio.chman `
     --installChannelUri C:\TEMP\VisualStudio.chman `

--- a/native-desktop/README.md
+++ b/native-desktop/README.md
@@ -7,20 +7,20 @@ We start from the microsoft/dotnet-framework:3.5-sdk-windowsservercore-1709 base
 To build this image from this directory, run:
 
 ```batch
-docker build -t buildtools2017native:latest -m 2GB .
+docker build -t buildtools2022native:latest -m 2GB .
 ```
 
 ## Running
 To map and build native sources from a clean source repository, run:
 
 ```batch
-docker run -m 2G -v %CD%:C:\src buildtools2017native:latest --name Solution msbuild /m c:\src\Solution.sln
+docker run -m 2G -v %CD%:C:\src buildtools2022native:latest --name Solution msbuild /m c:\src\Solution.sln
 ```
 
 You can optionally pass specific configurations to build as well.
 
 ```batch
-docker run -m 2G -v %CD%:C:\src buildtools2017native:latest --name Solution msbuild /m c:\src\Solution.sln /p:Configuration=Debug /p:Platform=x64
+docker run -m 2G -v %CD%:C:\src buildtools2022native:latest --name Solution msbuild /m c:\src\Solution.sln /p:Configuration=Debug /p:Platform=x64
 ```
 
 To build again run the container created in the previous step, e.g.

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -18,11 +18,11 @@ ADD https://nodejs.org/dist/v8.11.3/node-v8.11.3-x64.msi C:\TEMP\node-install.ms
 RUN start /wait msiexec.exe /i C:\TEMP\node-install.msi /l*vx "%TEMP%\MSI-node-install.log" /qn ADDLOCAL=ALL
 
 # Download channel for fixed install.
-ARG CHANNEL_URL=https://aka.ms/vs/15/release/channel
+ARG CHANNEL_URL=https://aka.ms/vs/17/release/channel
 ADD ${CHANNEL_URL} C:\TEMP\VisualStudio.chman
 
-# Download and install Build Tools for Visual Studio 2017.
-ADD https://aka.ms/vs/15/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
+# Download and install Build Tools for Visual Studio 2022.
+ADD https://aka.ms/vs/17/release/vs_buildtools.exe C:\TEMP\vs_buildtools.exe
 RUN C:\TEMP\Install.cmd C:\TEMP\vs_buildtools.exe --quiet --wait --norestart --nocache `
     --channelUri C:\TEMP\VisualStudio.chman `
     --installChannelUri C:\TEMP\VisualStudio.chman `

--- a/web/README.md
+++ b/web/README.md
@@ -9,7 +9,7 @@ On top of that we add the workloads for building .NET and .NET Core apps. Also a
 To build this image from this directory, run:
 
 ```batch
-docker build -t buildtools2017web:latest -m 2GB .
+docker build -t buildtools2022web:latest -m 2GB .
 ```
 ## Running with CAKE
 Assuming CAKE is used then a `build.ps1` script should be available. It can be run using the following command from a clean source repository:
@@ -18,10 +18,10 @@ Assuming CAKE is used then a `build.ps1` script should be available. It can be r
 docker run -m 2G ^
  -v %CD%:c:\src ^
  -w c:\src ^
- buildtools2017web:latest ^
+ buildtools2022web:latest ^
  powershell .\build.ps1 -Target="Default" -Transform="Debug" -Configuration="Debug
 ```
- - runs `buildtools2017web:latest` and passes in the current working directory `%CD%` and designates it `c:\src` 'inside' the container
+ - runs `buildtools2022web:latest` and passes in the current working directory `%CD%` and designates it `c:\src` 'inside' the container
  - designates the working directory to `c:\src`
  - starts the `build.ps1` script (in this instance with a debug config)
 
@@ -29,13 +29,13 @@ docker run -m 2G ^
 To map and build web sources from a clean source repository, run:
 
 ```batch
-docker run -m 2G -v %CD%:C:\src buildtools2017web:latest --name Solution msbuild /m c:\src\Solution.sln
+docker run -m 2G -v %CD%:C:\src buildtools2022web:latest --name Solution msbuild /m c:\src\Solution.sln
 ```
 
 You can optionally pass specific configurations to build as well.
 
 ```batch
-docker run -m 2G -v %CD%:C:\src buildtools2017web:latest --name Solution msbuild /m c:\src\Solution.sln /p:Configuration=Debug /p:Platform=x64
+docker run -m 2G -v %CD%:C:\src buildtools2022web:latest --name Solution msbuild /m c:\src\Solution.sln /p:Configuration=Debug /p:Platform=x64
 ```
 
 To build again run the container created in the previous step, e.g.


### PR DESCRIPTION
Upgrade from Visual Studio 2017 to 2022 as suggested on #14.

Have also renamed the `buildtools2022:latest`, `buildtools2022native:latest` and `buildtools2022web:latest` Docker image references to 2022.